### PR TITLE
Correct package README urls and bump version

### DIFF
--- a/Manufacturing/src/CSharp/Nuget/Package/Microsoft.Azure.Sphere.DeviceAPI.csproj
+++ b/Manufacturing/src/CSharp/Nuget/Package/Microsoft.Azure.Sphere.DeviceAPI.csproj
@@ -8,13 +8,13 @@
 		<Description>A package containing abstractions for Microsoft Azure Sphere Device REST APIs</Description>
 		<Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
 		<PackageId>Microsoft.Azure.Sphere.DeviceAPI</PackageId>
-		<Version>1.1.0</Version>
+		<Version>1.1.1</Version>
 		<PackageTags>Azure Sphere device rest api</PackageTags>
 		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<Nullable>disable</Nullable>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageProjectUrl>https://github.com/Azure/azure-sphere-samples</PackageProjectUrl>
+		<PackageProjectUrl>https://github.com/Azure/azure-sphere-tools</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 

--- a/Manufacturing/src/CSharp/Nuget/Package/docs/README.md
+++ b/Manufacturing/src/CSharp/Nuget/Package/docs/README.md
@@ -34,7 +34,7 @@ internal class Program
 
 1. Install Visual Studio
 
-1. Follow the guide to [add a nuget package to a Visual Studio project](https://learn.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio). 
+1. Follow the guide to [add a nuget package to a Visual Studio project](https://learn.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio).
 
 ## Usage
 

--- a/Manufacturing/src/CSharp/Nuget/Package/docs/README.md
+++ b/Manufacturing/src/CSharp/Nuget/Package/docs/README.md
@@ -36,7 +36,17 @@ internal class Program
 
 1. Follow the guide to [add a nuget package to a Visual Studio project](https://learn.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio).
 
+## Usage
+
+Before using Microsoft Azure Sphere Device REST APIs for CSharp, you must install the Azure Sphere SDK.
+
+- To install the Azure Sphere SDK on Windows, follow the [Windows Quickstart](https://learn.microsoft.com/azure-sphere/install/install-sdk?pivots=cli).
+- To install the Azure Sphere SDK on Linux, follow the [Linux Quickstart](https://learn.microsoft.com/azure-sphere/install/install-sdk-linux?pivots=cli-linux).
+
+### Sample
+
+The [DeviceApiSample](https://github.com/Azure/azure-sphere-tools/tree/main/Manufacturing/src/CSharp/DeviceAPISample) gets the list of attached devices, displays the device IP address, and device ID.
 
 ## API documentation
 
-View the package API documentation [on Github](https://github.com/Azure/azure-sphere-samples/blob/main/Manufacturing/src/README.md).
+View the package API documentation [on Github](https://github.com/Azure/azure-sphere-tools/blob/main/Manufacturing/src/README.md).

--- a/Manufacturing/src/CSharp/Nuget/Package/docs/README.md
+++ b/Manufacturing/src/CSharp/Nuget/Package/docs/README.md
@@ -50,3 +50,8 @@ The [DeviceApiSample](https://github.com/Azure/azure-sphere-tools/tree/main/Manu
 ## API documentation
 
 View the package API documentation [on Github](https://github.com/Azure/azure-sphere-tools/blob/main/Manufacturing/src/README.md).
+
+## Supported host operating systems
+
+- Windows 10 and 11
+- Ubuntu 18.04, 20.04, 22.04

--- a/Manufacturing/src/CSharp/Nuget/Package/docs/README.md
+++ b/Manufacturing/src/CSharp/Nuget/Package/docs/README.md
@@ -34,7 +34,7 @@ internal class Program
 
 1. Install Visual Studio
 
-1. Follow the guide to [add a nuget package to a Visual Studio project](https://learn.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio).
+1. Follow the guide to [add a nuget package to a Visual Studio project](https://learn.microsoft.com/en-us/nuget/quickstart/install-and-use-a-package-in-visual-studio). 
 
 ## Usage
 

--- a/Manufacturing/src/Python/package/README.md
+++ b/Manufacturing/src/Python/package/README.md
@@ -37,4 +37,4 @@ Microsoft Azure Sphere Device REST APIs for Python documentation is available at
 ## Supported host operating systems
 
 - Windows 10 and 11
-- Ubuntu 18.04 and 20.04
+- Ubuntu 18.04, 20.04, 22.04

--- a/Manufacturing/src/Python/package/README.md
+++ b/Manufacturing/src/Python/package/README.md
@@ -5,26 +5,26 @@ Microsoft Azure Sphere Device REST APIs for Python enables users to interact wit
 ## Installation
 
 You can find Microsoft Azure Sphere Device REST APIs for Python on [PyPi](https://pypi.org/project/azuresphere_device_api/).
+
 1. If you haven't already, [install and/or upgrade the pip](https://pip.pypa.io/en/stable/installing/)
    of your Python environment to a recent version.
 2. Run `pip install azuresphere_device_api`.
 
-## Versions
-
-This library follows [Semantic Versioning](http://semver.org/).
-
 ## Usage
 
 Before using Microsoft Azure Sphere Device REST APIs for Python, you must install the Azure Sphere SDK.
+
 - To install the Azure Sphere SDK on Windows, follow the [Windows Quickstart](https://learn.microsoft.com/azure-sphere/install/install-sdk?pivots=cli).
 - To install the Azure Sphere SDK on Linux, follow the [Linux Quickstart](https://learn.microsoft.com/azure-sphere/install/install-sdk-linux?pivots=cli-linux).
 
 ### Sample
-The [display_ip_deviceid sample](https://github.com/Azure/azure-sphere-samples/blob/main/Manufacturing/src/Python/device_api_sample) gets the list of attached devices, displays the device IP address, and device ID.
+
+The [display_ip_deviceid sample](https://github.com/Azure/azure-sphere-tools/blob/main/Manufacturing/src/Python/device_api_sample) gets the list of attached devices, displays the device IP address, and device ID.
 
 ### Active device IP address
 
 By default, this package will target Azure Sphere devices with IP address `192.168.35.2`. To change the active Azure Sphere device, call `set_active_device_ip_address` API as below:
+
 ```
 from azuresphere_device_api import devices
 devices.set_active_device_ip_address("<Device_Ip_Address")
@@ -32,9 +32,9 @@ devices.set_active_device_ip_address("<Device_Ip_Address")
 
 ## Documentation
 
-Microsoft Azure Sphere Device REST APIs for Python documentation is available at [Azure Sphere Device REST APIs Docs](https://github.com/Azure/azure-sphere-samples/blob/main/Manufacturing/src).
+Microsoft Azure Sphere Device REST APIs for Python documentation is available at [Azure Sphere Device REST APIs Docs](https://github.com/Azure/azure-sphere-tools/blob/main/Manufacturing/src).
 
 ## Supported host operating systems
 
-* Windows 10 and 11
-* Ubuntu 18.04 and 20.04
+- Windows 10 and 11
+- Ubuntu 18.04 and 20.04

--- a/Manufacturing/src/Python/package/pyproject.toml
+++ b/Manufacturing/src/Python/package/pyproject.toml
@@ -14,7 +14,7 @@ testpaths = [
 
 [project]
 name = "azuresphere-device-api"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
     { name="Microsoft", email="azspheremfrsamplesup@microsoft.com" }
 ]


### PR DESCRIPTION
The README files are now incorrect for the packages as they have been removed from azure-sphere-samples.

This PR updates the README files for each package and bumps the version.