### PR TITLE
Bump System.Management.Automation

### DIFF
--- a/Manufacturing/src/CSharp/Nuget/Package/Microsoft.Azure.Sphere.DeviceAPI.csproj
+++ b/Manufacturing/src/CSharp/Nuget/Package/Microsoft.Azure.Sphere.DeviceAPI.csproj
@@ -29,7 +29,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="System.Management.Automation" Version="7.2.5" />
+		<PackageReference Include="System.Management.Automation" Version="7.2.12" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Manufacturing/src/CSharp/Nuget/Tests/DeviceAPITest/DeviceAPITest/DeviceAPITest.csproj
+++ b/Manufacturing/src/CSharp/Nuget/Tests/DeviceAPITest/DeviceAPITest/DeviceAPITest.csproj
@@ -14,7 +14,7 @@
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
 		<PackageReference Include="coverlet.collector" Version="3.1.2" />
 		<PackageReference Include="JsonSchema.Net" Version="4.0.1" />
-		<PackageReference Include="System.Management.Automation" Version="7.2.5" />
+		<PackageReference Include="System.Management.Automation" Version="7.2.12" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
System.Management.Automation has a security risk in its dependencies, specifically System.Security.Cryptography.Pkcs. The latest version of the package does not.