### PR TITLE
Address dotnet 8 compat break

### DIFF
--- a/scripts/PackageBuild.psm1
+++ b/scripts/PackageBuild.psm1
@@ -7,11 +7,20 @@ Invoke the specified dotnet command, throwing an exception if the return code is
 #>
 function Invoke-Dotnet()
 {
+    param(
+        [Parameter()] [switch] $release
+    )
+
     if ($args.Count -eq 0) {
         throw "Must supply args to dotnet command"
     }
 
-    & dotnet $args
+    $config = "Debug"
+    if ($release) {
+        $config = "Release"
+    }
+
+    & dotnet /c $config $args
 
     $result = $LASTEXITCODE
 


### PR DESCRIPTION
.NET 8 changes the behaviour of `dotnet pack` and `dotnet publish` to use Debug rather than release by default (whereas all the other commands still default to Debug and not Release, of course.)

We should explicitly specify which it is we want to use.