### PR TITLE
The device will return an error when setting a blank manufacturing state

### DIFF
--- a/Manufacturing/src/CSharp/Nuget/Tests/DeviceAPITest/DeviceAPITest/ManufacturingTests/SetManufacturingStateTests.cs
+++ b/Manufacturing/src/CSharp/Nuget/Tests/DeviceAPITest/DeviceAPITest/ManufacturingTests/SetManufacturingStateTests.cs
@@ -51,9 +51,13 @@ namespace TestDeviceRestAPI.ManufacturingTests
             string startGetResponse = Manufacturing.GetManufacturingState();
             string currentState = JsonConvert.DeserializeObject<Dictionary<string, string>>(startGetResponse)["manufacturingState"];
 
-            string setResponse = Manufacturing.SetDeviceManufacturingState(currentState);
-
-            Assert.AreEqual("{}", setResponse);
+            if (currentState == "Blank") {
+                // It is invalid to try and set a device to manufacturing state "Blank", so we expect an error in this case
+                DeviceError error = Assert.ThrowsException<DeviceError>( () => Manufacturing.SetDeviceManufacturingState(currentState));
+            } else {
+                string setResponse = Manufacturing.SetDeviceManufacturingState(currentState);
+                Assert.AreEqual("{}", setResponse);
+            }
 
             string endGetResponse = Manufacturing.GetManufacturingState();
 


### PR DESCRIPTION
The C# tests expect a valid response when setting a blank manufacturing state on a device with a blank manufacturing state. This is incorrect - the device will return an error in this case. This PR fixes that.