### PR TITLE
Migrate azure-sphere-tools pipeline to OneBranch

### DIFF
--- a/.azuredevops/build-release.yml
+++ b/.azuredevops/build-release.yml
@@ -45,11 +45,11 @@ variables:
   WindowsContainerImage: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
 
 extends:
-  template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines
+  template: /v2/OneBranch.Official.CrossPlat.yml@oneBranchPipelines
   parameters:
     featureFlags:
       WindowsHostVersion:
         Version: 2022
         Network: KS1
     stages:
-    - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts
+    - template: builds/azure-sphere-tools/templates/azure-sphere-tools-release.yml@SdkBuildScripts

--- a/.azuredevops/build-release.yml
+++ b/.azuredevops/build-release.yml
@@ -1,0 +1,53 @@
+name: $(date:yyyyMMdd)$(rev:.rr)-$(BuildID)
+
+resources:
+  repositories:
+  - repository: self
+    clean: true
+  - repository: SdkBuildScripts
+    clean: true
+    name: SdkBuildScripts
+    type: git
+    ref: refs/heads/dev/snehara/replace-scripts
+  - repository: oneBranchPipelines
+    type: git
+    name: OneBranch.Pipelines/GovernedTemplates
+    ref: refs/heads/main
+
+trigger:
+  branches:
+    include:
+    - main
+
+schedules:
+- cron: 0 4 * * * # Daily at 4am GMT
+  displayName: "Daily main"
+  branches:
+    include:
+    - main
+  always: true
+
+variables:
+  Codeql.Enabled: true
+  PythonVersion: '3.x'
+  DotNetVersion: '6.0.x'
+  # Disable automatic Nuget Security Analysis injection so we can place the
+  # nuget.config files in place and then manually run `task: nuget-security-analysis@0`
+  skipNugetSecurityAnalysis: true
+  system.debug: true
+  ReleaseOrMain: $[
+    or(
+    eq( variables['Build.SourceBranch'], 'refs/heads/main'),
+    startswith(variables['Build.SourceBranch'], 'refs/heads/release')
+    ) ]
+  WindowsContainerImage: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
+
+extends:
+  template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines
+  parameters:
+    featureFlags:
+      WindowsHostVersion:
+        Version: 2022
+        Network: KS1
+    stages:
+    - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts

--- a/.azuredevops/build-release.yml
+++ b/.azuredevops/build-release.yml
@@ -6,7 +6,7 @@ resources:
     clean: true
     name: SdkBuildScripts
     type: git
-    ref: refs/heads/dev/snehara/replace-scripts
+    ref: refs/heads/main
   - repository: oneBranchPipelines
     type: git
     name: OneBranch.Pipelines/GovernedTemplates

--- a/.azuredevops/build-release.yml
+++ b/.azuredevops/build-release.yml
@@ -2,8 +2,6 @@ name: $(date:yyyyMMdd)$(rev:.rr)-$(BuildID)
 
 resources:
   repositories:
-  - repository: self
-    clean: true
   - repository: SdkBuildScripts
     clean: true
     name: SdkBuildScripts
@@ -13,7 +11,11 @@ resources:
     type: git
     name: OneBranch.Pipelines/GovernedTemplates
     ref: refs/heads/main
-
+  - repository: azure-sphere-tools
+    clean: true
+    type: github
+    name: Azure/azure-sphere-tools
+    endpoint: 4x4
 trigger:
   branches:
     include:

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -49,7 +49,7 @@ variables:
     ) ]
 
 extends:
-  ${{ if eq(variables['Official'], false) }}: # REVERT AFTER TESTING
+  ${{ if eq(variables['Official'], true) }}: 
     template: /v2/OneBranch.Official.CrossPlat.yml@oneBranchPipelines
   ${{ else }}:
     template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -41,13 +41,14 @@ variables:
     eq( variables['Build.SourceBranch'], 'refs/heads/main'),
     startswith(variables['Build.SourceBranch'], 'refs/heads/release')
     ) ]
-  WindowsContainerImage: onebranch.azurecr.io/windows/ltsc2019/vse2022:latest
+  WindowsContainerImage: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
 
 extends:
   template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines
   parameters:
     featureFlags:
       WindowsHostVersion:
-          Network: KS1
+        Version: 2022
+        Network: KS1
     stages:
     - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -41,6 +41,7 @@ variables:
     eq( variables['Build.SourceBranch'], 'refs/heads/main'),
     startswith(variables['Build.SourceBranch'], 'refs/heads/release')
     ) ]
+  WindowsContainerImage: onebranch.azurecr.io/windows/ltsc2019/vse2022:latest
 
 extends:
   template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines
@@ -49,6 +50,10 @@ extends:
     - stage: sanity_stage
       jobs:
         - job: sanity_check
+          pool:
+            type: windows
+          workspace:
+            clean: all
           steps:
           - task: PowerShell@2
             inputs:

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -53,18 +53,18 @@ extends:
     - stage: hello_world_1
       displayName: Hello World 1
       jobs:
-      - job: print_hello
-        variables:
-        - name: ob_outputDirectory
-          value: "$(build.ArtifactStagingDirectory)/hello_world"
-        displayName: "Print Hello World"
+        - job: print_hello
+          variables:
+          - name: ob_outputDirectory
+            value: "$(build.ArtifactStagingDirectory)/hello_world"
+          displayName: "Print Hello World"
 
-        steps:
-        - task: PowerShell@2
-          displayName: "Hello World"
-          inputs:
-            targetType: inline
-            script: |
-              Write-Output "Hello World"
+          steps:
+          - task: PowerShell@2
+            displayName: "Hello World"
+            inputs:
+              targetType: inline
+              script: |
+                Write-Output "Hello World"
 
     # - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -36,11 +36,11 @@ variables:
   # nuget.config files in place and then manually run `task: nuget-security-analysis@0`
   skipNugetSecurityAnalysis: true
   system.debug: true
-  # ReleaseOrMain: $[
-  #   or(
-  #   eq( variables['Build.SourceBranch'], 'refs/heads/main'),
-  #   startswith(variables['Build.SourceBranch'], 'refs/heads/release')
-  #   ) ]
+  ReleaseOrMain: $[
+    or(
+    eq( variables['Build.SourceBranch'], 'refs/heads/main'),
+    startswith(variables['Build.SourceBranch'], 'refs/heads/release')
+    ) ]
   WindowsContainerImage: onebranch.azurecr.io/windows/ltsc2019/vse2022:latest
 
 extends:
@@ -50,21 +50,20 @@ extends:
       WindowsHostVersion:
           Network: KS1
     stages:
-    - stage: hello_world_1
-      displayName: Hello World 1
+    - stage: sanity_stage
       jobs:
-      - job: print_hello
-        variables:
-        - name: ob_outputDirectory
-          value: "$(build.ArtifactStagingDirectory)/hello_world"
-        displayName: "Print Hello World"
-
-        steps:
-        - task: PowerShell@2
-          displayName: "Hello World"
-          inputs:
-            targetType: inline
-            script: |
-              Write-Output "Hello World"
-
+        - job: sanity_check
+          pool:
+            type: windows
+          workspace:
+            clean: all
+          variables:
+          - name: ob_outputDirectory
+            value: "$(build.ArtifactStagingDirectory)/azure-sphere-tools"
+          steps:
+          - task: PowerShell@2
+            inputs:
+              targetType: "inline"
+              script: |
+                Write-Output "Hello, World!"
     # - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -9,6 +9,10 @@ resources:
     name: SdkBuildScripts
     type: git
     ref: refs/heads/dev/snehara/replace-scripts
+  - repository: oneBranchPipelines
+    type: git
+    name: OneBranch.Pipelines/GovernedTemplates
+    ref: refs/heads/main
 
 trigger:
   branches:
@@ -24,5 +28,19 @@ schedules:
     - main
   always: true
 
+variables:
+  Official: $[
+    or(
+    eq( variables['Build.SourceBranch'], 'refs/heads/main'),
+    startswith(variables['Build.SourceBranch'], 'refs/heads/release'),
+    startswith(variables['Build.SourceBranch'], 'refs/heads/prerelease')
+    ) ]
+
 extends:
-  template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts
+  ${{ if eq(variables['Official'], true) }}: 
+    template: /v2/OneBranch.Official.CrossPlat.yml@oneBranchPipelines
+  ${{ else }}:
+    template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines
+  parameters:
+    stages:
+    - template: builds/azure-sphere-tools/stages/azure-sphere-tools-build.yml@SdkBuildScripts

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -8,7 +8,7 @@ resources:
     clean: true
     name: SdkBuildScripts
     type: git
-    ref: refs/heads/dev/snehara/replace-scripts
+    ref: refs/heads/main
   - repository: oneBranchPipelines
     type: git
     name: OneBranch.Pipelines/GovernedTemplates

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -8,6 +8,7 @@ resources:
     clean: true
     name: SdkBuildScripts
     type: git
+    ref: refs/heads/dev/snehara/consolidate-yml
 
 trigger:
   branches:

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -36,11 +36,11 @@ variables:
   # nuget.config files in place and then manually run `task: nuget-security-analysis@0`
   skipNugetSecurityAnalysis: true
   system.debug: true
-  ReleaseOrMain: $[
-    or(
-    eq( variables['Build.SourceBranch'], 'refs/heads/main'),
-    startswith(variables['Build.SourceBranch'], 'refs/heads/release')
-    ) ]
+  # ReleaseOrMain: $[
+  #   or(
+  #   eq( variables['Build.SourceBranch'], 'refs/heads/main'),
+  #   startswith(variables['Build.SourceBranch'], 'refs/heads/release')
+  #   ) ]
   WindowsContainerImage: onebranch.azurecr.io/windows/ltsc2019/vse2022:latest
 
 extends:
@@ -50,20 +50,21 @@ extends:
       WindowsHostVersion:
           Network: KS1
     stages:
-    - stage: sanity_stage
+    - stage: hello_world_1
+      displayName: Hello World 1
       jobs:
-        - job: sanity_check
-          pool:
-            type: windows
-          workspace:
-            clean: all
-          variables:
-          - name: ob_outputDirectory
-            value: "$(build.ArtifactStagingDirectory)/azure-sphere-tools"
-          steps:
-          - task: PowerShell@2
-            inputs:
-              targetType: "inline"
-              script: |
-                Write-Output "Hello, World!"
+      - job: print_hello
+        variables:
+        - name: ob_outputDirectory
+          value: "$(build.ArtifactStagingDirectory)/hello_world"
+        displayName: "Print Hello World"
+
+        steps:
+        - task: PowerShell@2
+          displayName: "Hello World"
+          inputs:
+            targetType: inline
+            script: |
+              Write-Output "Hello World"
+
     # - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -49,7 +49,7 @@ variables:
     ) ]
 
 extends:
-  ${{ if eq(variables['Official'], true) }}: 
+  ${{ if eq(variables['Official'], false) }}: # REVERT AFTER TESTING
     template: /v2/OneBranch.Official.CrossPlat.yml@oneBranchPipelines
   ${{ else }}:
     template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -36,11 +36,11 @@ variables:
   # nuget.config files in place and then manually run `task: nuget-security-analysis@0`
   skipNugetSecurityAnalysis: true
   system.debug: true
-  # ReleaseOrMain: $[
-  #   or(
-  #   eq( variables['Build.SourceBranch'], 'refs/heads/main'),
-  #   startswith(variables['Build.SourceBranch'], 'refs/heads/release')
-  #   ) ]
+  ReleaseOrMain: $[
+    or(
+    eq( variables['Build.SourceBranch'], 'refs/heads/main'),
+    startswith(variables['Build.SourceBranch'], 'refs/heads/release')
+    ) ]
   WindowsContainerImage: onebranch.azurecr.io/windows/ltsc2019/vse2022:latest
 
 extends:
@@ -54,6 +54,10 @@ extends:
       displayName: Hello World 1
       jobs:
         - job: print_hello
+          pool:
+            type: windows
+          workspace:
+            clean: all
           variables:
           - name: ob_outputDirectory
             value: "$(build.ArtifactStagingDirectory)/hello_world"

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -50,4 +50,21 @@ extends:
       WindowsHostVersion:
           Network: KS1
     stages:
+    - stage: hello_world_1
+      displayName: Hello World 1
+      jobs:
+      - job: print_hello
+        variables:
+        - name: ob_outputDirectory
+          value: "$(build.ArtifactStagingDirectory)/hello_world"
+        displayName: "Print Hello World"
+
+        steps:
+        - task: PowerShell@2
+          displayName: "Hello World"
+          inputs:
+            targetType: inline
+            script: |
+              Write-Output "Hello World"
+
     - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -35,6 +35,18 @@ variables:
     startswith(variables['Build.SourceBranch'], 'refs/heads/release'),
     startswith(variables['Build.SourceBranch'], 'refs/heads/prerelease')
     ) ]
+  Codeql.Enabled: true
+  PythonVersion: '3.x'
+  DotNetVersion: '6.0.x'
+  # Disable automatic Nuget Security Analysis injection so we can place the
+  # nuget.config files in place and then manually run `task: nuget-security-analysis@0`
+  skipNugetSecurityAnalysis: true
+  system.debug: true
+  ReleaseOrMain: $[
+    or(
+    eq( variables['Build.SourceBranch'], 'refs/heads/main'),
+    startswith(variables['Build.SourceBranch'], 'refs/heads/release')
+    ) ]
 
 extends:
   ${{ if eq(variables['Official'], true) }}: 

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -8,6 +8,7 @@ resources:
     clean: true
     name: SdkBuildScripts
     type: git
+    ref: refs/heads/dev/snehara/replace-scripts
   - repository: oneBranchPipelines
     type: git
     name: OneBranch.Pipelines/GovernedTemplates

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -46,7 +46,8 @@ extends:
   template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines
   parameters:
     stages:
-       jobs:
+    - stage: sanity_stage
+      jobs:
         - job: sanity_check
           steps:
           - task: PowerShell@2

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -29,12 +29,6 @@ schedules:
   always: true
 
 variables:
-  Official: $[
-    or(
-    eq( variables['Build.SourceBranch'], 'refs/heads/main'),
-    startswith(variables['Build.SourceBranch'], 'refs/heads/release'),
-    startswith(variables['Build.SourceBranch'], 'refs/heads/prerelease')
-    ) ]
   Codeql.Enabled: true
   PythonVersion: '3.x'
   DotNetVersion: '6.0.x'
@@ -49,10 +43,7 @@ variables:
     ) ]
 
 extends:
-  # ${{ if eq(variables['Official'], true) }}: 
-  template: /v2/OneBranch.Official.CrossPlat.yml@oneBranchPipelines
-  # ${{ else }}:
-  #   template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines
+  template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines
   parameters:
     stages:
     - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -8,7 +8,7 @@ resources:
     clean: true
     name: SdkBuildScripts
     type: git
-    ref: refs/heads/dev/snehara/consolidate-yml
+    ref: refs/heads/dev/snehara/replace-scripts
 
 trigger:
   branches:

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -49,10 +49,10 @@ variables:
     ) ]
 
 extends:
-  ${{ if eq(variables['Official'], true) }}: 
-    template: /v2/OneBranch.Official.CrossPlat.yml@oneBranchPipelines
-  ${{ else }}:
-    template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines
+  # ${{ if eq(variables['Official'], true) }}: 
+  template: /v2/OneBranch.Official.CrossPlat.yml@oneBranchPipelines
+  # ${{ else }}:
+  #   template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines
   parameters:
     stages:
     - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -54,6 +54,9 @@ extends:
             type: windows
           workspace:
             clean: all
+          variables:
+          - name: ob_outputDirectory
+            value: "$(build.ArtifactStagingDirectory)/azure-sphere-tools"
           steps:
           - task: PowerShell@2
             inputs:

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -43,4 +43,4 @@ extends:
     template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines
   parameters:
     stages:
-    - template: builds/azure-sphere-tools/stages/azure-sphere-tools-build.yml@SdkBuildScripts
+    - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -50,25 +50,4 @@ extends:
       WindowsHostVersion:
           Network: KS1
     stages:
-    - stage: hello_world_1
-      displayName: Hello World 1
-      jobs:
-        - job: print_hello
-          pool:
-            type: windows
-          workspace:
-            clean: all
-          variables:
-          - name: ob_outputDirectory
-            value: "$(build.ArtifactStagingDirectory)/hello_world"
-          displayName: "Print Hello World"
-
-          steps:
-          - task: PowerShell@2
-            displayName: "Hello World"
-            inputs:
-              targetType: inline
-              script: |
-                Write-Output "Hello World"
-
-    # - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts
+    - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -67,4 +67,4 @@ extends:
             script: |
               Write-Output "Hello World"
 
-    - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts
+    # - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -8,7 +8,6 @@ resources:
     clean: true
     name: SdkBuildScripts
     type: git
-    ref: refs/heads/dev/snehara/replace-scripts
   - repository: oneBranchPipelines
     type: git
     name: OneBranch.Pipelines/GovernedTemplates

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -46,4 +46,12 @@ extends:
   template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines
   parameters:
     stages:
-    - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts
+       jobs:
+        - job: sanity_check
+          steps:
+          - task: PowerShell@2
+            inputs:
+              targetType: "inline"
+              script: |
+                Write-Output "Hello, World!"
+    # - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -46,6 +46,9 @@ variables:
 extends:
   template: /v2/OneBranch.NonOfficial.CrossPlat.yml@oneBranchPipelines
   parameters:
+    featureFlags:
+      WindowsHostVersion:
+          Network: KS1
     stages:
     - stage: sanity_stage
       jobs:

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -36,11 +36,11 @@ variables:
   # nuget.config files in place and then manually run `task: nuget-security-analysis@0`
   skipNugetSecurityAnalysis: true
   system.debug: true
-  ReleaseOrMain: $[
-    or(
-    eq( variables['Build.SourceBranch'], 'refs/heads/main'),
-    startswith(variables['Build.SourceBranch'], 'refs/heads/release')
-    ) ]
+  # ReleaseOrMain: $[
+  #   or(
+  #   eq( variables['Build.SourceBranch'], 'refs/heads/main'),
+  #   startswith(variables['Build.SourceBranch'], 'refs/heads/release')
+  #   ) ]
   WindowsContainerImage: onebranch.azurecr.io/windows/ltsc2019/vse2022:latest
 
 extends:

--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -50,20 +50,4 @@ extends:
       WindowsHostVersion:
           Network: KS1
     stages:
-    - stage: sanity_stage
-      jobs:
-        - job: sanity_check
-          pool:
-            type: windows
-          workspace:
-            clean: all
-          variables:
-          - name: ob_outputDirectory
-            value: "$(build.ArtifactStagingDirectory)/azure-sphere-tools"
-          steps:
-          - task: PowerShell@2
-            inputs:
-              targetType: "inline"
-              script: |
-                Write-Output "Hello, World!"
-    # - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts
+    - template: builds/azure-sphere-tools/templates/azure-sphere-tools.yml@SdkBuildScripts

--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,9 @@
+{
+    "instanceUrl": "https://dev.azure.com/msazuresphere",
+    "projectName": "4x4",
+    "areaPath": "4x4\\Gen1\\Tooling",
+    "template": "VSTS_AZSphere",
+    "notificationAliases": [
+        "asphere-sdk-accel@microsoft.com"
+    ]
+}

--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -5,5 +5,6 @@
     "template": "VSTS_AZSphere",
     "notificationAliases": [
         "asphere-sdk-accel@microsoft.com"
-    ]
+    ],
+    "codebaseName": "azure-sphere-tools"
 }


### PR DESCRIPTION
Migrated the azure-sphere-tools pipeline to OneBranch.

Split the original pipeline into two separate pipelines:
- build+test pipeline: [Azure.azure-sphere-tools](https://dev.azure.com/msazuresphere/4x4/_build/results?buildId=579677&view=results)
- build+release pipeline: [Azure.azure-sphere-tools-build-release](https://dev.azure.com/msazuresphere/4x4/_build?definitionId=2433&_a=summary) (this is a new pipeline)