### PR TITLE
Fix azure-sphere-tools repo reference in build pipeline

### DIFF
--- a/.azuredevops/build.yml
+++ b/.azuredevops/build.yml
@@ -2,8 +2,6 @@ name: $(date:yyyyMMdd)$(rev:.rr)-$(BuildID)
 
 resources:
   repositories:
-  - repository: self
-    clean: true
   - repository: SdkBuildScripts
     clean: true
     name: SdkBuildScripts
@@ -13,7 +11,11 @@ resources:
     type: git
     name: OneBranch.Pipelines/GovernedTemplates
     ref: refs/heads/main
-
+  - repository: azure-sphere-tools
+    clean: true
+    type: github
+    name: Azure/azure-sphere-tools
+    endpoint: 4x4
 trigger:
   branches:
     include:


### PR DESCRIPTION
azure-sphere-tools repository reference was being used in template yml files without being properly defined in the parent build.yml resulting in errors like the one you see here: https://dev.azure.com/msazuresphere/4x4/_build/results?buildId=584342&view=results